### PR TITLE
Use a faster priority queue implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 /__pycache__
+*.pyc
+
+# Text editor temp files
+*~
+\#*\#

--- a/FibonacciHeap.py
+++ b/FibonacciHeap.py
@@ -93,6 +93,7 @@ class FibHeap:
         if self.minnode == None:
             raise AssertionError("Cannot remove from an empty heap")
 
+        removed_node = self.minnode
         self.count -= 1
 
         # 1: Assign all old root children as new roots
@@ -113,7 +114,7 @@ class FibHeap:
             if self.count != 0:
                 raise AssertionError("Heap error: Expected 0 keys, count is " + str(self.count))
             self.minnode = None
-            return
+            return removed_node
 
         # 2.2: Merge any roots with the same degree
         logsize = 100
@@ -153,6 +154,8 @@ class FibHeap:
                     newmaxdegree = d
 
         maxdegree = newmaxdegree
+
+        return removed_node
 
 
     def decreasekey(self, node, newkey):

--- a/astar.py
+++ b/astar.py
@@ -1,4 +1,4 @@
-from FibonacciHeap import FibHeap
+from priority_queue import FibPQ
 
 # This implementatoin of A* is almost identical to the Dijkstra implementation. So for clarity I've removed all comments, and only added those
 # Specifically showing the difference between dijkstra and A*
@@ -18,19 +18,19 @@ def solve(maze):
     infinity = float("inf")
     distances = [infinity] * total
 
-    unvisited = FibHeap()
+    unvisited = FibPQ()
 
     nodeindex = [None] * total
 
     distances[start.Position[0] * width + start.Position[1]] = 0
-    startnode = FibHeap.Node(0, start)
+    startnode = (0, start)
     nodeindex[start.Position[0] * width + start.Position[1]] = startnode
     unvisited.insert(startnode)
 
     count = 0
     completed = False
 
-    while unvisited.count > 0:
+    while len(unvisited) > 0:
         count += 1
 
         n = unvisited.minimum()
@@ -72,7 +72,7 @@ def solve(maze):
                             # V goes into the priority queue with a cost of g + f. So if it's moving closer to the end, it'll get higher
                             # priority than some other nodes. The order we visit nodes is a trade-off between a short path, and moving
                             # closer to the goal.
-                            vnode = FibHeap.Node(newdistance + remaining, v)
+                            vnode = (newdistance + remaining, v)
                             unvisited.insert(vnode)
                             nodeindex[vposindex] = vnode
                             # The distance *to* the node remains just g, no f included.

--- a/astar.py
+++ b/astar.py
@@ -21,8 +21,8 @@ def solve(maze):
 
     # The priority queue. There are multiple implementations in priority_queue.py
     # unvisited = FibHeap()
-    # unvisited = HeapPQ()
-    unvisited = FibPQ()
+    unvisited = HeapPQ()
+    # unvisited = FibPQ()
     # unvisited = QueuePQ()
 
     nodeindex = [None] * total
@@ -38,8 +38,7 @@ def solve(maze):
     while len(unvisited) > 0:
         count += 1
 
-        n = unvisited.minimum()
-        unvisited.removeminimum()
+        n = unvisited.removeminimum()
 
         u = n.value
         upos = u.Position

--- a/astar.py
+++ b/astar.py
@@ -1,4 +1,5 @@
-from priority_queue import FibPQ, HeapPQ
+from FibonacciHeap import FibHeap
+from priority_queue import FibPQ, HeapPQ, QueuePQ
 
 # This implementatoin of A* is almost identical to the Dijkstra implementation. So for clarity I've removed all comments, and only added those
 # Specifically showing the difference between dijkstra and A*
@@ -19,13 +20,15 @@ def solve(maze):
     distances = [infinity] * total
 
     # The priority queue. There are multiple implementations in priority_queue.py
-    # unvisited = FibPQ()
-    unvisited = HeapPQ()
+    # unvisited = FibHeap()
+    # unvisited = HeapPQ()
+    unvisited = FibPQ()
+    # unvisited = QueuePQ()
 
     nodeindex = [None] * total
 
     distances[start.Position[0] * width + start.Position[1]] = 0
-    startnode = (0, start)
+    startnode = FibHeap.Node(0, start)
     nodeindex[start.Position[0] * width + start.Position[1]] = startnode
     unvisited.insert(startnode)
 
@@ -38,7 +41,7 @@ def solve(maze):
         n = unvisited.minimum()
         unvisited.removeminimum()
 
-        u = n
+        u = n.value
         upos = u.Position
         uposindex = upos[0] * width + upos[1]
 
@@ -74,7 +77,7 @@ def solve(maze):
                             # V goes into the priority queue with a cost of g + f. So if it's moving closer to the end, it'll get higher
                             # priority than some other nodes. The order we visit nodes is a trade-off between a short path, and moving
                             # closer to the goal.
-                            vnode = (newdistance + remaining, v)
+                            vnode = FibHeap.Node(newdistance + remaining, v)
                             unvisited.insert(vnode)
                             nodeindex[vposindex] = vnode
                             # The distance *to* the node remains just g, no f included.

--- a/astar.py
+++ b/astar.py
@@ -1,4 +1,4 @@
-from priority_queue import FibPQ
+from priority_queue import FibPQ, HeapPQ
 
 # This implementatoin of A* is almost identical to the Dijkstra implementation. So for clarity I've removed all comments, and only added those
 # Specifically showing the difference between dijkstra and A*
@@ -18,7 +18,9 @@ def solve(maze):
     infinity = float("inf")
     distances = [infinity] * total
 
-    unvisited = FibPQ()
+    # The priority queue. There are multiple implementations in priority_queue.py
+    # unvisited = FibPQ()
+    unvisited = HeapPQ()
 
     nodeindex = [None] * total
 
@@ -36,7 +38,7 @@ def solve(maze):
         n = unvisited.minimum()
         unvisited.removeminimum()
 
-        u = n.value
+        u = n
         upos = u.Position
         uposindex = upos[0] * width + upos[1]
 

--- a/astar.py
+++ b/astar.py
@@ -4,96 +4,96 @@ from FibonacciHeap import FibHeap
 # Specifically showing the difference between dijkstra and A*
 
 def solve(maze):
-	width = maze.width
-	total = maze.width * maze.height
+    width = maze.width
+    total = maze.width * maze.height
 
-	start = maze.start
-	startpos = start.Position
-	end = maze.end
-	endpos = end.Position
+    start = maze.start
+    startpos = start.Position
+    end = maze.end
+    endpos = end.Position
 
-	visited = [False] * total
-	prev = [None] * total
+    visited = [False] * total
+    prev = [None] * total
 
-	infinity = float("inf")
-	distances = [infinity] * total
+    infinity = float("inf")
+    distances = [infinity] * total
 
-	unvisited = FibHeap()
+    unvisited = FibHeap()
 
-	nodeindex = [None] * total
+    nodeindex = [None] * total
 
-	distances[start.Position[0] * width + start.Position[1]] = 0
-	startnode = FibHeap.Node(0, start)
-	nodeindex[start.Position[0] * width + start.Position[1]] = startnode
-	unvisited.insert(startnode)
+    distances[start.Position[0] * width + start.Position[1]] = 0
+    startnode = FibHeap.Node(0, start)
+    nodeindex[start.Position[0] * width + start.Position[1]] = startnode
+    unvisited.insert(startnode)
 
-	count = 0
-	completed = False
+    count = 0
+    completed = False
 
-	while unvisited.count > 0:
-		count += 1
+    while unvisited.count > 0:
+        count += 1
 
-		n = unvisited.minimum()
-		unvisited.removeminimum()
+        n = unvisited.minimum()
+        unvisited.removeminimum()
 
-		u = n.value
-		upos = u.Position
-		uposindex = upos[0] * width + upos[1]
+        u = n.value
+        upos = u.Position
+        uposindex = upos[0] * width + upos[1]
 
-		if distances[uposindex] == infinity:
-			break
+        if distances[uposindex] == infinity:
+            break
 
-		if upos == endpos:
-			completed = True
-			break
+        if upos == endpos:
+            completed = True
+            break
 
-		for v in u.Neighbours:
-			if v != None:
-				vpos = v.Position
-				vposindex = vpos[0] * width + vpos[1]
+        for v in u.Neighbours:
+            if v != None:
+                vpos = v.Position
+                vposindex = vpos[0] * width + vpos[1]
 
-				if visited[vposindex] == False:
-					d = abs(vpos[0] - upos[0]) + abs(vpos[1] - upos[1])
+                if visited[vposindex] == False:
+                    d = abs(vpos[0] - upos[0]) + abs(vpos[1] - upos[1])
 
-					# New path cost to v is distance to u + extra. Some descriptions of A* call this the g cost.
-					# New distance is the distance of the path from the start, through U, to V.
-					newdistance = distances[uposindex] + d
+                    # New path cost to v is distance to u + extra. Some descriptions of A* call this the g cost.
+                    # New distance is the distance of the path from the start, through U, to V.
+                    newdistance = distances[uposindex] + d
 
-					# A* includes a remaining cost, the f cost. In this case we use manhattan distance to calculate the distance from
-					# V to the end. We use manhattan again because A* works well when the g cost and f cost are balanced.
-					# https://en.wikipedia.org/wiki/Taxicab_geometry
-					remaining = abs(vpos[0] - endpos[0]) + abs(vpos[1] - endpos[1])
+                    # A* includes a remaining cost, the f cost. In this case we use manhattan distance to calculate the distance from
+                    # V to the end. We use manhattan again because A* works well when the g cost and f cost are balanced.
+                    # https://en.wikipedia.org/wiki/Taxicab_geometry
+                    remaining = abs(vpos[0] - endpos[0]) + abs(vpos[1] - endpos[1])
 
-					# Notice that we don't include f cost in this first check. We want to know that the path *to* our node V is shortest
-					if newdistance < distances[vposindex]:
-						vnode = nodeindex[vposindex]
+                    # Notice that we don't include f cost in this first check. We want to know that the path *to* our node V is shortest
+                    if newdistance < distances[vposindex]:
+                        vnode = nodeindex[vposindex]
 
-						if vnode == None:
-							# V goes into the priority queue with a cost of g + f. So if it's moving closer to the end, it'll get higher
-							# priority than some other nodes. The order we visit nodes is a trade-off between a short path, and moving
-							# closer to the goal.
-							vnode = FibHeap.Node(newdistance + remaining, v)
-							unvisited.insert(vnode)
-							nodeindex[vposindex] = vnode
-							# The distance *to* the node remains just g, no f included.
-							distances[vposindex] = newdistance
-							prev[vposindex] = u
-						else:
-							# As above, we decrease the node since we've found a new path. But we include the f cost, the distance remaining.
-							unvisited.decreasekey(vnode, newdistance + remaining)
-							# The distance *to* the node remains just g, no f included.
-							distances[vposindex] = newdistance
-							prev[vposindex] = u
+                        if vnode == None:
+                            # V goes into the priority queue with a cost of g + f. So if it's moving closer to the end, it'll get higher
+                            # priority than some other nodes. The order we visit nodes is a trade-off between a short path, and moving
+                            # closer to the goal.
+                            vnode = FibHeap.Node(newdistance + remaining, v)
+                            unvisited.insert(vnode)
+                            nodeindex[vposindex] = vnode
+                            # The distance *to* the node remains just g, no f included.
+                            distances[vposindex] = newdistance
+                            prev[vposindex] = u
+                        else:
+                            # As above, we decrease the node since we've found a new path. But we include the f cost, the distance remaining.
+                            unvisited.decreasekey(vnode, newdistance + remaining)
+                            # The distance *to* the node remains just g, no f included.
+                            distances[vposindex] = newdistance
+                            prev[vposindex] = u
 
 
-		visited[uposindex] = True
+        visited[uposindex] = True
 
-	from collections import deque
+    from collections import deque
 
-	path = deque()
-	current = end
-	while (current != None):
-		path.appendleft(current)
-		current = prev[current.Position[0] * width + current.Position[1]]
+    path = deque()
+    current = end
+    while (current != None):
+        path.appendleft(current)
+        current = prev[current.Position[0] * width + current.Position[1]]
 
-	return [path, [count, len(path), completed]]
+    return [path, [count, len(path), completed]]

--- a/breadthfirst.py
+++ b/breadthfirst.py
@@ -1,42 +1,42 @@
 from collections import deque
 
 def solve(maze):
-	start = maze.start
-	end = maze.end
+    start = maze.start
+    end = maze.end
 
-	width = maze.width
+    width = maze.width
 
-	queue = deque([start])
-	shape = (maze.height, maze.width)
-	prev = [None] * (maze.width * maze.height)
-	visited = [False] * (maze.width * maze.height)
+    queue = deque([start])
+    shape = (maze.height, maze.width)
+    prev = [None] * (maze.width * maze.height)
+    visited = [False] * (maze.width * maze.height)
 
-	count = 0
+    count = 0
 
-	completed = False
+    completed = False
 
-	visited[start.Position[0] * width + start.Position[1]] = True
+    visited[start.Position[0] * width + start.Position[1]] = True
 
-	while queue:
-		count += 1
-		current = queue.pop()
+    while queue:
+        count += 1
+        current = queue.pop()
 
-		if current == end:
-			completed = True
-			break
+        if current == end:
+            completed = True
+            break
 
-		for n in current.Neighbours:
-			if n != None:
-				npos = n.Position[0] * width + n.Position[1]
-				if visited[npos] == False:
-					queue.appendleft(n)
-					visited[npos] = True
-					prev[npos] = current
+        for n in current.Neighbours:
+            if n != None:
+                npos = n.Position[0] * width + n.Position[1]
+                if visited[npos] == False:
+                    queue.appendleft(n)
+                    visited[npos] = True
+                    prev[npos] = current
 
-	path = deque()
-	current = end
-	while (current != None):
-		path.appendleft(current)
-		current = prev[current.Position[0] * width + current.Position[1]]
+    path = deque()
+    current = end
+    while (current != None):
+        path.appendleft(current)
+        current = prev[current.Position[0] * width + current.Position[1]]
 
-	return [path, [count, len(path), completed]]
+    return [path, [count, len(path), completed]]

--- a/depthfirst.py
+++ b/depthfirst.py
@@ -1,40 +1,40 @@
 from collections import deque
 
 def solve(maze):
-	start = maze.start
-	end = maze.end
-	width = maze.width
-	stack = deque([start])
-	shape = (maze.height, maze.width)
-	prev = [None] * (maze.width * maze.height)
-	visited = [False] * (maze.width * maze.height)
-	count = 0
+    start = maze.start
+    end = maze.end
+    width = maze.width
+    stack = deque([start])
+    shape = (maze.height, maze.width)
+    prev = [None] * (maze.width * maze.height)
+    visited = [False] * (maze.width * maze.height)
+    count = 0
 
-	completed = False
-	while stack:
-		count += 1
-		current = stack.pop()
+    completed = False
+    while stack:
+        count += 1
+        current = stack.pop()
 
-		if current == end:
-			completed = True
-			break
+        if current == end:
+            completed = True
+            break
 
-		visited[current.Position[0] * width + current.Position[1]] = True
+        visited[current.Position[0] * width + current.Position[1]] = True
 
-		#import code
-		#code.interact(local=locals())
+        #import code
+        #code.interact(local=locals())
 
-		for n in current.Neighbours:
-			if n != None:
-				npos = n.Position[0] * width + n.Position[1]
-				if visited[npos] == False:
-					stack.append(n)
-					prev[npos] = current
+        for n in current.Neighbours:
+            if n != None:
+                npos = n.Position[0] * width + n.Position[1]
+                if visited[npos] == False:
+                    stack.append(n)
+                    prev[npos] = current
 
-	path = deque()
-	current = end
-	while (current != None):
-		path.appendleft(current)
-		current = prev[current.Position[0] * width + current.Position[1]]
+    path = deque()
+    current = end
+    while (current != None):
+        path.appendleft(current)
+        current = prev[current.Position[0] * width + current.Position[1]]
 
-	return [path, [count, len(path), completed]]
+    return [path, [count, len(path), completed]]

--- a/dijkstra.py
+++ b/dijkstra.py
@@ -25,8 +25,8 @@ def solve(maze):
 
     # The priority queue. There are multiple implementations in priority_queue.py
     # unvisited = FibHeap()
-    # unvisited = HeapPQ()
-    unvisited = FibPQ()
+    unvisited = HeapPQ()
+    # unvisited = FibPQ()
     # unvisited = QueuePQ()
 
     # This index holds all priority queue nodes as they are created. We use this to decrease the key of a specific node when a shorter path is found.
@@ -48,8 +48,7 @@ def solve(maze):
         count += 1
 
         # Find current shortest path point to explore
-        n = unvisited.minimum()
-        unvisited.removeminimum()
+        n = unvisited.removeminimum()
 
         # Current node u, all neighbours will be v
         u = n.value

--- a/dijkstra.py
+++ b/dijkstra.py
@@ -1,4 +1,4 @@
-from priority_queue import FibPQ
+from priority_queue import FibPQ, HeapPQ
 
 def solve(maze):
     # Width is used for indexing, total is used for array sizes
@@ -22,8 +22,9 @@ def solve(maze):
     infinity = float("inf")
     distances = [infinity] * total
 
-    # The priority queue. We are using a Fibonacci heap in this case.
-    unvisited = FibPQ()
+    # The priority queue. There are multiple implementations in priority_queue.py
+    # unvisited = FibPQ()
+    unvisited = HeapPQ()
 
     # This index holds all priority queue nodes as they are created. We use this to decrease the key of a specific node when a shorter path is found.
     # This isn't hugely memory efficient, but likely to be faster than a dictionary or similar.
@@ -48,7 +49,7 @@ def solve(maze):
         unvisited.removeminimum()
 
         # Current node u, all neighbours will be v
-        u = n.value
+        u = n
         upos = u.Position
         uposindex = upos[0] * width + upos[1]
 

--- a/dijkstra.py
+++ b/dijkstra.py
@@ -1,104 +1,104 @@
 from FibonacciHeap import FibHeap
 
 def solve(maze):
-	# Width is used for indexing, total is used for array sizes
-	width = maze.width
-	total = maze.width * maze.height
+    # Width is used for indexing, total is used for array sizes
+    width = maze.width
+    total = maze.width * maze.height
 
-	# Start node, end node
-	start = maze.start
-	startpos = start.Position
-	end = maze.end
-	endpos = end.Position
+    # Start node, end node
+    start = maze.start
+    startpos = start.Position
+    end = maze.end
+    endpos = end.Position
 
-	# Visited holds true/false on whether a node has been seen already. Used to stop us returning to nodes multiple times
-	visited = [False] * total
+    # Visited holds true/false on whether a node has been seen already. Used to stop us returning to nodes multiple times
+    visited = [False] * total
 
-	# Previous holds a link to the previous node in the path. Used at the end for reconstructing the route
-	prev = [None] * total
+    # Previous holds a link to the previous node in the path. Used at the end for reconstructing the route
+    prev = [None] * total
 
-	# Distances holds the distance to any node taking the best known path so far. Better paths replace worse ones as we find them.
-	# We start with all distances at infinity
-	infinity = float("inf")
-	distances = [infinity] * total
+    # Distances holds the distance to any node taking the best known path so far. Better paths replace worse ones as we find them.
+    # We start with all distances at infinity
+    infinity = float("inf")
+    distances = [infinity] * total
 
-	# The priority queue. We are using a Fibonacci heap in this case.
-	unvisited = FibHeap()
+    # The priority queue. We are using a Fibonacci heap in this case.
+    unvisited = FibHeap()
 
-	# This index holds all priority queue nodes as they are created. We use this to decrease the key of a specific node when a shorter path is found.
-	# This isn't hugely memory efficient, but likely to be faster than a dictionary or similar.
-	nodeindex = [None] * total
+    # This index holds all priority queue nodes as they are created. We use this to decrease the key of a specific node when a shorter path is found.
+    # This isn't hugely memory efficient, but likely to be faster than a dictionary or similar.
+    nodeindex = [None] * total
 
-	# To begin, we set the distance to the start to zero (we're there) and add it into the unvisited queue
-	distances[start.Position[0] * width + start.Position[1]] = 0
-	startnode = FibHeap.Node(0, start)
-	nodeindex[start.Position[0] * width + start.Position[1]] = startnode
-	unvisited.insert(startnode)
+    # To begin, we set the distance to the start to zero (we're there) and add it into the unvisited queue
+    distances[start.Position[0] * width + start.Position[1]] = 0
+    startnode = FibHeap.Node(0, start)
+    nodeindex[start.Position[0] * width + start.Position[1]] = startnode
+    unvisited.insert(startnode)
 
-	# Zero nodes visited, and not completed yet.
-	count = 0
-	completed = False
+    # Zero nodes visited, and not completed yet.
+    count = 0
+    completed = False
 
-	# Begin Dijkstra - continue while there are unvisited nodes in the queue
-	while unvisited.count > 0:
-		count += 1
+    # Begin Dijkstra - continue while there are unvisited nodes in the queue
+    while unvisited.count > 0:
+        count += 1
 
-		# Find current shortest path point to explore
-		n = unvisited.minimum()
-		unvisited.removeminimum()
+        # Find current shortest path point to explore
+        n = unvisited.minimum()
+        unvisited.removeminimum()
 
-		# Current node u, all neighbours will be v
-		u = n.value
-		upos = u.Position
-		uposindex = upos[0] * width + upos[1]
+        # Current node u, all neighbours will be v
+        u = n.value
+        upos = u.Position
+        uposindex = upos[0] * width + upos[1]
 
-		if distances[uposindex] == infinity:
-			break
+        if distances[uposindex] == infinity:
+            break
 
-		# If upos == endpos, we're done!
-		if upos == endpos:
-			completed = True
-			break
+        # If upos == endpos, we're done!
+        if upos == endpos:
+            completed = True
+            break
 
-		for v in u.Neighbours:
-			if v != None:
-				vpos = v.Position
-				vposindex = vpos[0] * width + vpos[1]
+        for v in u.Neighbours:
+            if v != None:
+                vpos = v.Position
+                vposindex = vpos[0] * width + vpos[1]
 
-				if visited[vposindex] == False:
-					# The extra distance from where we are (upos) to the neighbour (vpos) - this is manhattan distance
-					# https://en.wikipedia.org/wiki/Taxicab_geometry
-					d = abs(vpos[0] - upos[0]) + abs(vpos[1] - upos[1])
+                if visited[vposindex] == False:
+                    # The extra distance from where we are (upos) to the neighbour (vpos) - this is manhattan distance
+                    # https://en.wikipedia.org/wiki/Taxicab_geometry
+                    d = abs(vpos[0] - upos[0]) + abs(vpos[1] - upos[1])
 
-					# New path cost to v is distance to u + extra
-					newdistance = distances[uposindex] + d
+                    # New path cost to v is distance to u + extra
+                    newdistance = distances[uposindex] + d
 
-					# If this new distance is the new shortest path to v
-					if newdistance < distances[vposindex]:
-						vnode = nodeindex[vposindex]
-						# v isn't already in the priority queue - add it
-						if vnode == None:
-							vnode = FibHeap.Node(newdistance, v)
-							unvisited.insert(vnode)
-							nodeindex[vposindex] = vnode
-							distances[vposindex] = newdistance
-							prev[vposindex] = u
-						# v is already in the queue - decrease its key to re-prioritise it
-						else:
-							unvisited.decreasekey(vnode, newdistance)
-							distances[vposindex] = newdistance
-							prev[vposindex] = u
+                    # If this new distance is the new shortest path to v
+                    if newdistance < distances[vposindex]:
+                        vnode = nodeindex[vposindex]
+                        # v isn't already in the priority queue - add it
+                        if vnode == None:
+                            vnode = FibHeap.Node(newdistance, v)
+                            unvisited.insert(vnode)
+                            nodeindex[vposindex] = vnode
+                            distances[vposindex] = newdistance
+                            prev[vposindex] = u
+                        # v is already in the queue - decrease its key to re-prioritise it
+                        else:
+                            unvisited.decreasekey(vnode, newdistance)
+                            distances[vposindex] = newdistance
+                            prev[vposindex] = u
 
-		visited[uposindex] = True
+        visited[uposindex] = True
 
 
-	# We want to reconstruct the path. We start at end, and then go prev[end] and follow all the prev[] links until we're back at the start
-	from collections import deque
+    # We want to reconstruct the path. We start at end, and then go prev[end] and follow all the prev[] links until we're back at the start
+    from collections import deque
 
-	path = deque()
-	current = end
-	while (current != None):
-		path.appendleft(current)
-		current = prev[current.Position[0] * width + current.Position[1]]
+    path = deque()
+    current = end
+    while (current != None):
+        path.appendleft(current)
+        current = prev[current.Position[0] * width + current.Position[1]]
 
-	return [path, [count, len(path), completed]]
+    return [path, [count, len(path), completed]]

--- a/dijkstra.py
+++ b/dijkstra.py
@@ -1,4 +1,5 @@
-from priority_queue import FibPQ, HeapPQ
+from FibonacciHeap import FibHeap
+from priority_queue import FibPQ, HeapPQ, QueuePQ
 
 def solve(maze):
     # Width is used for indexing, total is used for array sizes
@@ -23,8 +24,10 @@ def solve(maze):
     distances = [infinity] * total
 
     # The priority queue. There are multiple implementations in priority_queue.py
-    # unvisited = FibPQ()
-    unvisited = HeapPQ()
+    # unvisited = FibHeap()
+    # unvisited = HeapPQ()
+    unvisited = FibPQ()
+    # unvisited = QueuePQ()
 
     # This index holds all priority queue nodes as they are created. We use this to decrease the key of a specific node when a shorter path is found.
     # This isn't hugely memory efficient, but likely to be faster than a dictionary or similar.
@@ -32,7 +35,7 @@ def solve(maze):
 
     # To begin, we set the distance to the start to zero (we're there) and add it into the unvisited queue
     distances[start.Position[0] * width + start.Position[1]] = 0
-    startnode = (0, start)
+    startnode = FibHeap.Node(0, start)
     nodeindex[start.Position[0] * width + start.Position[1]] = startnode
     unvisited.insert(startnode)
 
@@ -49,7 +52,7 @@ def solve(maze):
         unvisited.removeminimum()
 
         # Current node u, all neighbours will be v
-        u = n
+        u = n.value
         upos = u.Position
         uposindex = upos[0] * width + upos[1]
 
@@ -79,7 +82,7 @@ def solve(maze):
                         vnode = nodeindex[vposindex]
                         # v isn't already in the priority queue - add it
                         if vnode == None:
-                            vnode = (newdistance, v)
+                            vnode = FibHeap.Node(newdistance, v)
                             unvisited.insert(vnode)
                             nodeindex[vposindex] = vnode
                             distances[vposindex] = newdistance

--- a/dijkstra.py
+++ b/dijkstra.py
@@ -1,4 +1,4 @@
-from FibonacciHeap import FibHeap
+from priority_queue import FibPQ
 
 def solve(maze):
     # Width is used for indexing, total is used for array sizes
@@ -23,7 +23,7 @@ def solve(maze):
     distances = [infinity] * total
 
     # The priority queue. We are using a Fibonacci heap in this case.
-    unvisited = FibHeap()
+    unvisited = FibPQ()
 
     # This index holds all priority queue nodes as they are created. We use this to decrease the key of a specific node when a shorter path is found.
     # This isn't hugely memory efficient, but likely to be faster than a dictionary or similar.
@@ -31,7 +31,7 @@ def solve(maze):
 
     # To begin, we set the distance to the start to zero (we're there) and add it into the unvisited queue
     distances[start.Position[0] * width + start.Position[1]] = 0
-    startnode = FibHeap.Node(0, start)
+    startnode = (0, start)
     nodeindex[start.Position[0] * width + start.Position[1]] = startnode
     unvisited.insert(startnode)
 
@@ -40,7 +40,7 @@ def solve(maze):
     completed = False
 
     # Begin Dijkstra - continue while there are unvisited nodes in the queue
-    while unvisited.count > 0:
+    while len(unvisited) > 0:
         count += 1
 
         # Find current shortest path point to explore
@@ -78,7 +78,7 @@ def solve(maze):
                         vnode = nodeindex[vposindex]
                         # v isn't already in the priority queue - add it
                         if vnode == None:
-                            vnode = FibHeap.Node(newdistance, v)
+                            vnode = (newdistance, v)
                             unvisited.insert(vnode)
                             nodeindex[vposindex] = vnode
                             distances[vposindex] = newdistance

--- a/factory.py
+++ b/factory.py
@@ -2,23 +2,23 @@
 # Not hugely necessary, but reduces the code in solve.py, making it easier to read.
 
 class SolverFactory:
-	def __init__(self):
-		self.Default = "breadthfirst"
-		self.Choices = ["breadthfirst","depthfirst","dijkstra", "astar","leftturn"]
+    def __init__(self):
+        self.Default = "breadthfirst"
+        self.Choices = ["breadthfirst","depthfirst","dijkstra", "astar","leftturn"]
 
-	def createsolver(self, type):
-		if type == "leftturn":
-			import leftturn
-			return ["Left turn only", leftturn.solve]
-		elif type == "depthfirst":
-			import depthfirst
-			return ["Depth first search", depthfirst.solve]
-		elif type == "dijkstra":
-			import dijkstra
-			return ["Dijkstra's Algorithm", dijkstra.solve]
-		elif type == "astar":
-			import astar
-			return ["A-star Search", astar.solve]
-		else:
-			import breadthfirst
-			return ["Breadth first search", breadthfirst.solve]
+    def createsolver(self, type):
+        if type == "leftturn":
+            import leftturn
+            return ["Left turn only", leftturn.solve]
+        elif type == "depthfirst":
+            import depthfirst
+            return ["Depth first search", depthfirst.solve]
+        elif type == "dijkstra":
+            import dijkstra
+            return ["Dijkstra's Algorithm", dijkstra.solve]
+        elif type == "astar":
+            import astar
+            return ["A-star Search", astar.solve]
+        else:
+            import breadthfirst
+            return ["Breadth first search", breadthfirst.solve]

--- a/leftturn.py
+++ b/leftturn.py
@@ -2,59 +2,59 @@ from collections import deque
 
 def solve(maze):
 
-	path = deque([maze.start])
+    path = deque([maze.start])
 
-	current = maze.start.Neighbours[2]
+    current = maze.start.Neighbours[2]
 
-	if current == None:
-		return path
+    if current == None:
+        return path
 
-	heading = 2 # South
+    heading = 2 # South
 
-	turn = 1 # Turning left, -1 for right
+    turn = 1 # Turning left, -1 for right
 
-	startpos = maze.start.Position
-	endpos = maze.end.Position
+    startpos = maze.start.Position
+    endpos = maze.end.Position
 
-	# N E S W - just a helpful reminder
-	# 0 1 2 3
+    # N E S W - just a helpful reminder
+    # 0 1 2 3
 
-	count = 1
+    count = 1
 
-	completed = False
+    completed = False
 
 
-	while True:
-		path.append(current)
-		count += 1
-		position = current.Position
-		if position == startpos or position == endpos:
-			if position == endpos:
-				completed = True
-			break
+    while True:
+        path.append(current)
+        count += 1
+        position = current.Position
+        if position == startpos or position == endpos:
+            if position == endpos:
+                completed = True
+            break
 
-		n = current.Neighbours
+        n = current.Neighbours
 
-		if n[(heading - turn) % 4] != None:
-			heading = (heading - turn) % 4
-			current = n[heading]
-			continue
+        if n[(heading - turn) % 4] != None:
+            heading = (heading - turn) % 4
+            current = n[heading]
+            continue
 
-		if n[heading] != None:
-			current = n[heading]
-			continue
+        if n[heading] != None:
+            current = n[heading]
+            continue
 
-		if n[(heading + turn) % 4] != None:
-			heading = (heading + turn) % 4
-			current = n[heading]
-			continue
+        if n[(heading + turn) % 4] != None:
+            heading = (heading + turn) % 4
+            current = n[heading]
+            continue
 
-		if n[(heading + 2) % 4] != None:
-			heading = (heading + 2) % 4
-			current = n[heading]
-			continue
+        if n[(heading + 2) % 4] != None:
+            heading = (heading + 2) % 4
+            current = n[heading]
+            continue
 
-		completed = False
-		break
+        completed = False
+        break
 
-	return [path, [count, len(path), completed]]
+    return [path, [count, len(path), completed]]

--- a/mazes.py
+++ b/mazes.py
@@ -1,111 +1,111 @@
 class Maze:
-	class Node:
-		def __init__(self, position):
-			self.Position = position
-			self.Neighbours = [None, None, None, None]
-			#self.Weights = [0, 0, 0, 0]
+    class Node:
+        def __init__(self, position):
+            self.Position = position
+            self.Neighbours = [None, None, None, None]
+            #self.Weights = [0, 0, 0, 0]
 
-	def __init__(self, im):
+    def __init__(self, im):
 
-		width = im.width
-		height = im.height
-		data = list(im.getdata(0))
+        width = im.width
+        height = im.height
+        data = list(im.getdata(0))
 
-		self.start = None
-		self.end = None
+        self.start = None
+        self.end = None
 
-		# Top row buffer
-		topnodes = [None] * width
-		count = 0
+        # Top row buffer
+        topnodes = [None] * width
+        count = 0
 
-		# Start row
-		for x in range (1, width - 1):
-			if data[x] > 0:
-				self.start = Maze.Node((0,x))
-				topnodes[x] = self.start
-				count += 1
+        # Start row
+        for x in range (1, width - 1):
+            if data[x] > 0:
+                self.start = Maze.Node((0,x))
+                topnodes[x] = self.start
+                count += 1
 
-		for y in range (1, height - 1):
-			#print ("row", str(y)) # Uncomment this line to keep a track of row progress
+        for y in range (1, height - 1):
+            #print ("row", str(y)) # Uncomment this line to keep a track of row progress
 
-			rowoffset = y * width
-			rowaboveoffset = rowoffset - width
-			rowbelowoffset = rowoffset + width
+            rowoffset = y * width
+            rowaboveoffset = rowoffset - width
+            rowbelowoffset = rowoffset + width
 
-			# Initialise previous, current and next values
-			prv = False
-			cur = False
-			nxt = data[rowoffset + 1] > 0
+            # Initialise previous, current and next values
+            prv = False
+            cur = False
+            nxt = data[rowoffset + 1] > 0
 
-			leftnode = None
+            leftnode = None
 
-			for x in range (1, width - 1):
-				# Move prev, current and next onwards. This way we read from the image once per pixel, marginal optimisation
-				prv = cur
-				cur = nxt
-				nxt = data[rowoffset + x + 1] > 0
+            for x in range (1, width - 1):
+                # Move prev, current and next onwards. This way we read from the image once per pixel, marginal optimisation
+                prv = cur
+                cur = nxt
+                nxt = data[rowoffset + x + 1] > 0
 
-				n = None
+                n = None
 
-				if cur == False:
-					# ON WALL - No action
-					continue
+                if cur == False:
+                    # ON WALL - No action
+                    continue
 
-				if prv == True:
-					if nxt == True:
-						# PATH PATH PATH
-						# Create node only if paths above or below
-						if data[rowaboveoffset + x] > 0 or data[rowbelowoffset + x] > 0:
-							n = Maze.Node((y,x))
-							leftnode.Neighbours[1] = n
-							n.Neighbours[3] = leftnode
-							leftnode = n
-					else:
-						# PATH PATH WALL
-						# Create path at end of corridor
-						n = Maze.Node((y,x))
-						leftnode.Neighbours[1] = n
-						n.Neighbours[3] = leftnode
-						leftnode = None
-				else:
-					if nxt == True:
-						# WALL PATH PATH
-						# Create path at start of corridor
-						n = Maze.Node((y,x))
-						leftnode = n
-					else:
-						# WALL PATH WALL
-						# Create node only if in dead end
-						if (data[rowaboveoffset + x] == 0) or (data[rowbelowoffset + x] == 0):
-							#print ("Create Node in dead end")
-							n = Maze.Node((y,x))
+                if prv == True:
+                    if nxt == True:
+                        # PATH PATH PATH
+                        # Create node only if paths above or below
+                        if data[rowaboveoffset + x] > 0 or data[rowbelowoffset + x] > 0:
+                            n = Maze.Node((y,x))
+                            leftnode.Neighbours[1] = n
+                            n.Neighbours[3] = leftnode
+                            leftnode = n
+                    else:
+                        # PATH PATH WALL
+                        # Create path at end of corridor
+                        n = Maze.Node((y,x))
+                        leftnode.Neighbours[1] = n
+                        n.Neighbours[3] = leftnode
+                        leftnode = None
+                else:
+                    if nxt == True:
+                        # WALL PATH PATH
+                        # Create path at start of corridor
+                        n = Maze.Node((y,x))
+                        leftnode = n
+                    else:
+                        # WALL PATH WALL
+                        # Create node only if in dead end
+                        if (data[rowaboveoffset + x] == 0) or (data[rowbelowoffset + x] == 0):
+                            #print ("Create Node in dead end")
+                            n = Maze.Node((y,x))
 
-				# If node isn't none, we can assume we can connect N-S somewhere
-				if n != None:
-					# Clear above, connect to waiting top node
-					if (data[rowaboveoffset + x] > 0):
-						t = topnodes[x]
-						t.Neighbours[2] = n
-						n.Neighbours[0] = t
+                # If node isn't none, we can assume we can connect N-S somewhere
+                if n != None:
+                    # Clear above, connect to waiting top node
+                    if (data[rowaboveoffset + x] > 0):
+                        t = topnodes[x]
+                        t.Neighbours[2] = n
+                        n.Neighbours[0] = t
 
-					# If clear below, put this new node in the top row for the next connection
-					if (data[rowbelowoffset + x] > 0):
-						topnodes[x] = n
-					else:
-						topnodes[x] = None
+                    # If clear below, put this new node in the top row for the next connection
+                    if (data[rowbelowoffset + x] > 0):
+                        topnodes[x] = n
+                    else:
+                        topnodes[x] = None
 
-					count += 1
+                    count += 1
 
-		# End row
-		rowoffset = (height - 1) * width
-		for x in range (1, width - 1):
-			if data[rowoffset + x] > 0:
-				self.end = Maze.Node((height - 1,x))
-				t = topnodes[x]
-				t.Neighbours[2] = self.end
-				self.end.Neighbours[0] = t
-				count += 1
+        # End row
+        rowoffset = (height - 1) * width
+        for x in range (1, width - 1):
+            if data[rowoffset + x] > 0:
+                self.end = Maze.Node((height - 1,x))
+                t = topnodes[x]
+                t.Neighbours[2] = self.end
+                self.end.Neighbours[0] = t
+                count += 1
 
-		self.count = count
-		self.width = width
-		self.height = height
+        self.count = count
+        self.width = width
+        self.height = height

--- a/priority_queue.py
+++ b/priority_queue.py
@@ -1,6 +1,10 @@
 
 from abc import ABCMeta, abstractmethod
+import itertools
+
 from FibonacciHeap import FibHeap
+import heapq
+
 
 class PriorityQueue():
     __metaclass__ = ABCMeta
@@ -33,10 +37,46 @@ class FibPQ(PriorityQueue):
         self.heap.insert(node)
 
     def minimum(self):
-        return self.heap.minimum()
+        return self.heap.minimum().value
 
     def removeminimum(self):
         self.heap.removeminimum()
 
     def decreasekey(self, item, new_priority):
         self.heap.decreasekey(item, new_priority)
+
+# Adapted from
+# https://docs.python.org/2/library/heapq.html#priority-queue-implementation-notes
+class HeapPQ(PriorityQueue):
+    REMOVED_ITEM = '<removed-item>'
+
+    def __init__(self):
+        self.pq = []
+        self.entry_finder = {}
+        self.counter = itertools.count()
+
+    def __len__(self):
+        return len(self.pq)
+
+    def insert(self, priority_item):
+        (priority, item) = priority_item
+        if item in self.entry_finder:
+            self.remove(item)
+        entry = [priority, next(self.counter), item]
+        self.entry_finder[item] = entry
+        heapq.heappush(self.pq, entry)
+
+    def remove(self, item):
+        entry = self.entry_finder.pop(item)
+        entry[-1] = REMOVED_ITEM
+
+    def minimum(self):
+        [_, _, item] = min(self.pq)
+        return item
+
+    def removeminimum(self):
+        heapq.heappop(self.pq)
+
+    def decreasekey(self, item, new_priority):
+        self.remove(item)
+        self.insert((new_priority, item))

--- a/priority_queue.py
+++ b/priority_queue.py
@@ -38,7 +38,7 @@ class FibPQ(PriorityQueue):
         return self.heap.minimum()
 
     def removeminimum(self):
-        self.heap.removeminimum()
+        return self.heap.removeminimum()
 
     def decreasekey(self, node, new_priority):
         self.heap.decreasekey(node, new_priority)
@@ -67,10 +67,12 @@ class HeapPQ(PriorityQueue):
 
     def removeminimum(self):
         while True:
-            candidate = heapq.heappop(self.pq)
-            if candidate not in self.removed:
+            (priority, item) = heapq.heappop(self.pq)
+            if (priority, item) in self.removed:
+                self.removed.discard((priority, item))
+            else:
                 self.count -= 1
-                break
+                return FibHeap.Node(priority, item)
 
     def remove(self, node):
         entry = node.key, node.value
@@ -108,10 +110,12 @@ class QueuePQ(PriorityQueue):
 
     def removeminimum(self):
         while True:
-            candidate = self.pq.get_nowait()
-            if candidate not in self.removed:
+            (priority, item) = self.pq.get_nowait()
+            if (priority, item) in self.removed:
+                self.removed.discard((priority, item))
+            else:
                 self.count -= 1
-                break
+                return FibHeap.Node(priority, item)
 
     def remove(self, node):
         entry = node.key, node.value

--- a/priority_queue.py
+++ b/priority_queue.py
@@ -1,0 +1,42 @@
+
+from abc import ABCMeta, abstractmethod
+from FibonacciHeap import FibHeap
+
+class PriorityQueue():
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def __len__(self): pass
+
+    @abstractmethod
+    def insert(self, priority_item): pass
+
+    @abstractmethod
+    def minimum(self): pass
+
+    @abstractmethod
+    def removeminimum(self): pass
+
+    @abstractmethod
+    def decreasekey(self, item, new_priority): pass
+
+class FibPQ(PriorityQueue):
+    def __init__(self):
+        self.heap = FibHeap()
+
+    def __len__(self):
+        return self.heap.count
+
+    def insert(self, priority_item):
+        (priority, item) = priority_item
+        node = FibHeap.Node(priority, item)
+        self.heap.insert(node)
+
+    def minimum(self):
+        return self.heap.minimum()
+
+    def removeminimum(self):
+        self.heap.removeminimum()
+
+    def decreasekey(self, item, new_priority):
+        self.heap.decreasekey(item, new_priority)

--- a/profile.py
+++ b/profile.py
@@ -6,19 +6,33 @@ import tempfile
 from solve import solve
 from factory import SolverFactory
 
-methods = [ "astar",
-            "breadthfirst",
-            "depthfirst",
-            "dijkstra",
-            "leftturn" ]
-
-inputs = [ "examples/perfect2k.png" ]
+methods = [
+    "astar",
+    # "breadthfirst",
+    # "depthfirst",
+    "dijkstra",
+    # "leftturn",
+]
+inputs = [
+    # "tiny",
+    # "small",
+    # "normal",
+    # "braid200",
+    "logo",
+    "combo400",
+    "braid2k",
+    "perfect2k",
+    # "perfect4k",
+    # "combo6k",
+    # "perfect10k",
+    # "vertical15k",
+]
 
 def profile():
     for m in methods:
         for i in inputs:
             with tempfile.NamedTemporaryFile(suffix='.png') as tmp:
-                solve(SolverFactory(), m, i, tmp.name)
+                solve(SolverFactory(), m, "examples/%s.png" % i, tmp.name)
 
 profiler = BProfile('profiler.png')
 with profiler:

--- a/profile.py
+++ b/profile.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+from bprofile import BProfile
+
+import tempfile
+from solve import solve
+from factory import SolverFactory
+
+methods = [ "astar",
+            "breadthfirst",
+            "depthfirst",
+            "dijkstra",
+            "leftturn" ]
+
+inputs = [ "examples/perfect2k.png" ]
+
+def profile():
+    for m in methods:
+        for i in inputs:
+            with tempfile.NamedTemporaryFile(suffix='.png') as tmp:
+                solve(SolverFactory(), m, i, tmp.name)
+
+profiler = BProfile('profiler.png')
+with profiler:
+    profile()

--- a/solve.py
+++ b/solve.py
@@ -9,7 +9,7 @@ import argparse
 sf = SolverFactory()
 parser = argparse.ArgumentParser()
 parser.add_argument("-m", "--method", nargs='?', const=sf.Default, default=sf.Default,
-						choices=sf.Choices)
+                                                choices=sf.Choices)
 parser.add_argument("input_file")
 parser.add_argument("output_file")
 args = parser.parse_args()
@@ -42,9 +42,9 @@ total = t1-t0
 # Print solve stats
 print ("Nodes explored: ", stats[0])
 if (stats[2]):
-	print ("Path found, length", stats[1])
+    print ("Path found, length", stats[1])
 else:
-	print ("No Path Found")
+    print ("No Path Found")
 print ("Time elapsed: ", total, "\n")
 
 """
@@ -69,21 +69,21 @@ length = len(resultpath)
 
 px = [0, 0, 0]
 for i in range(0, length - 1):
-	a = resultpath[i]
-	b = resultpath[i+1]
+    a = resultpath[i]
+    b = resultpath[i+1]
 
-	# Blue - red
-	px[0] = int((i / length) * 255)
-	px[2] = 255 - px[0]
+    # Blue - red
+    px[0] = int((i / length) * 255)
+    px[2] = 255 - px[0]
 
-	if a[0] == b[0]:
-		# Ys equal - horizontal line
-		for x in range(min(a[1],b[1]), max(a[1],b[1])):
-			out[a[0],x,:] = px
-	elif a[1] == b[1]:
-		# Xs equal - vertical line
-		for y in range(min(a[0],b[0]), max(a[0],b[0]) + 1):
-			out[y,a[1],:] = px
+    if a[0] == b[0]:
+        # Ys equal - horizontal line
+        for x in range(min(a[1],b[1]), max(a[1],b[1])):
+            out[a[0],x,:] = px
+    elif a[1] == b[1]:
+        # Xs equal - vertical line
+        for y in range(min(a[0],b[0]), max(a[0],b[0]) + 1):
+            out[y,a[1],:] = px
 
 img = Image.fromarray(out)
 img.save(args.output_file)

--- a/solve.py
+++ b/solve.py
@@ -6,84 +6,92 @@ from factory import SolverFactory
 
 # Read command line arguments - the python argparse class is convenient here.
 import argparse
-sf = SolverFactory()
-parser = argparse.ArgumentParser()
-parser.add_argument("-m", "--method", nargs='?', const=sf.Default, default=sf.Default,
-                                                choices=sf.Choices)
-parser.add_argument("input_file")
-parser.add_argument("output_file")
-args = parser.parse_args()
 
-method = args.method
+def solve(factory, method, input_file, output_file):
+    # Load Image
+    print ("Loading Image")
+    im = Image.open(input_file)
 
-# Load Image
-print ("Loading Image")
-im = Image.open(args.input_file)
+    # Create the maze (and time it) - for many mazes this is more time consuming than solving the maze
+    print ("Creating Maze")
+    t0 = time.time()
+    maze = Maze(im)
+    t1 = time.time()
+    print ("Node Count:", maze.count)
+    total = t1-t0
+    print ("Time elapsed:", total, "\n")
 
-# Create the maze (and time it) - for many mazes this is more time consuming than solving the maze
-print ("Creating Maze")
-t0 = time.time()
-maze = Maze(im)
-t1 = time.time()
-print ("Node Count:", maze.count)
-total = t1-t0
-print ("Time elapsed:", total, "\n")
+    # Create and run solver
+    [title, solver] = factory.createsolver(method)
+    print ("Starting Solve:", title)
 
-# Create and run solver
-[title, solver] = sf.createsolver(args.method)
-print ("Starting Solve:", title)
+    t0 = time.time()
+    [result, stats] = solver(maze)
+    t1 = time.time()
 
-t0 = time.time()
-[result, stats] = solver(maze)
-t1 = time.time()
+    total = t1-t0
 
-total = t1-t0
+    # Print solve stats
+    print ("Nodes explored: ", stats[0])
+    if (stats[2]):
+        print ("Path found, length", stats[1])
+    else:
+        print ("No Path Found")
+    print ("Time elapsed: ", total, "\n")
 
-# Print solve stats
-print ("Nodes explored: ", stats[0])
-if (stats[2]):
-    print ("Path found, length", stats[1])
-else:
-    print ("No Path Found")
-print ("Time elapsed: ", total, "\n")
+    """
+    Create and save the output image.
+    This is simple drawing code that travels between each node in turn, drawing either
+    a horizontal or vertical line as required. Line colour is roughly interpolated between
+    blue and red depending on how far down the path this section is. Dependency on numpy
+    should be easy to remove at some point.
+    """
 
-"""
-Create and save the output image.
-This is simple drawing code that travels between each node in turn, drawing either
-a horizontal or vertical line as required. Line colour is roughly interpolated between
-blue and red depending on how far down the path this section is. Dependency on numpy
-should be easy to remove at some point.
-"""
+    print ("Saving Image")
+    mazeimage = np.array(im)
+    imout = np.array(mazeimage)
+    imout[imout==1] = 255
+    out = imout[:,:,np.newaxis]
 
-print ("Saving Image")
-mazeimage = np.array(im)
-imout = np.array(mazeimage)
-imout[imout==1] = 255
-out = imout[:,:,np.newaxis]
+    out = np.repeat(out, 3, axis=2)
 
-out = np.repeat(out, 3, axis=2)
+    resultpath = [n.Position for n in result]
 
-resultpath = [n.Position for n in result]
+    length = len(resultpath)
 
-length = len(resultpath)
+    px = [0, 0, 0]
+    for i in range(0, length - 1):
+        a = resultpath[i]
+        b = resultpath[i+1]
 
-px = [0, 0, 0]
-for i in range(0, length - 1):
-    a = resultpath[i]
-    b = resultpath[i+1]
+        # Blue - red
+        px[0] = int((i / length) * 255)
+        px[2] = 255 - px[0]
 
-    # Blue - red
-    px[0] = int((i / length) * 255)
-    px[2] = 255 - px[0]
+        if a[0] == b[0]:
+            # Ys equal - horizontal line
+            for x in range(min(a[1],b[1]), max(a[1],b[1])):
+                out[a[0],x,:] = px
+        elif a[1] == b[1]:
+            # Xs equal - vertical line
+            for y in range(min(a[0],b[0]), max(a[0],b[0]) + 1):
+                out[y,a[1],:] = px
 
-    if a[0] == b[0]:
-        # Ys equal - horizontal line
-        for x in range(min(a[1],b[1]), max(a[1],b[1])):
-            out[a[0],x,:] = px
-    elif a[1] == b[1]:
-        # Xs equal - vertical line
-        for y in range(min(a[0],b[0]), max(a[0],b[0]) + 1):
-            out[y,a[1],:] = px
+    img = Image.fromarray(out)
+    img.save(output_file)
 
-img = Image.fromarray(out)
-img.save(args.output_file)
+
+def main():
+    sf = SolverFactory()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-m", "--method", nargs='?', const=sf.Default, default=sf.Default,
+                        choices=sf.Choices)
+    parser.add_argument("input_file")
+    parser.add_argument("output_file")
+    args = parser.parse_args()
+
+    solve(sf, args.method, args.input_file, args.output_file)
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
A priority queue based on Python's `heapq` is significantly faster than `FibHeap`. The `PriorityQueue` abstract class establishes a standard interface used by both implementations, and minimal changes were required to `astar.py` and `dijkstra.py` to use it.

## Performance analysis

### FibPQ

![fibpq](https://cloud.githubusercontent.com/assets/77286/23335002/4cd9c7fa-fb60-11e6-8e7c-e52e1149acf9.png)

```
$ time python ./profile.py
Loading Image
Creating Maze
('Node Count:', 716516)
('Time elapsed:', 7.4103100299835205, '\n')
('Starting Solve:', 'A-star Search')
('Nodes explored: ', 462307)
('Path found, length', 8650)
('Time elapsed: ', 32.061322927474976, '\n')
Saving Image
Loading Image
Creating Maze
('Node Count:', 716516)
('Time elapsed:', 8.040678024291992, '\n')
('Starting Solve:', 'Breadth first search')
('Nodes explored: ', 512576)
('Path found, length', 8650)
('Time elapsed: ', 2.32486891746521, '\n')
Saving Image
Loading Image
Creating Maze
('Node Count:', 716516)
('Time elapsed:', 8.369711875915527, '\n')
('Starting Solve:', 'Depth first search')
('Nodes explored: ', 152711)
('Path found, length', 8650)
('Time elapsed: ', 0.6843249797821045, '\n')
Saving Image
Loading Image
Creating Maze
('Node Count:', 716516)
('Time elapsed:', 7.939746856689453, '\n')
('Starting Solve:', "Dijkstra's Algorithm")
('Nodes explored: ', 511299)
('Path found, length', 8650)
('Time elapsed: ', 39.57828378677368, '\n')
Saving Image
Loading Image
Creating Maze
('Node Count:', 716516)
('Time elapsed:', 9.189558982849121, '\n')
('Starting Solve:', 'Left turn only')
('Nodes explored: ', 582092)
('Path found, length', 582092)
('Time elapsed: ', 1.0989949703216553, '\n')
Saving Image
python profile.py  127.03s user 1.56s system 100% cpu 2:08.42 total
```


### HeapPQ

![heappq](https://cloud.githubusercontent.com/assets/77286/23335005/54256d48-fb60-11e6-894b-4181d80ba6cb.png)

```
$ time python ./profile.py
Loading Image
Creating Maze
('Node Count:', 716516)
('Time elapsed:', 7.687443017959595, '\n')
('Starting Solve:', 'A-star Search')
('Nodes explored: ', 462306)
('Path found, length', 8650)
('Time elapsed: ', 9.670147895812988, '\n')
Saving Image
Loading Image
Creating Maze
('Node Count:', 716516)
('Time elapsed:', 8.07496190071106, '\n')
('Starting Solve:', 'Breadth first search')
('Nodes explored: ', 512576)
('Path found, length', 8650)
('Time elapsed: ', 2.324921131134033, '\n')
Saving Image
Loading Image
Creating Maze
('Node Count:', 716516)
('Time elapsed:', 8.762192964553833, '\n')
('Starting Solve:', 'Depth first search')
('Nodes explored: ', 152711)
('Path found, length', 8650)
('Time elapsed: ', 0.719641923904419, '\n')
Saving Image
Loading Image
Creating Maze
('Node Count:', 716516)
('Time elapsed:', 8.0798499584198, '\n')
('Starting Solve:', "Dijkstra's Algorithm")
('Nodes explored: ', 511299)
('Path found, length', 8650)
('Time elapsed: ', 12.476689100265503, '\n')
Saving Image
Loading Image
Creating Maze
('Node Count:', 716516)
('Time elapsed:', 8.351932048797607, '\n')
('Starting Solve:', 'Left turn only')
('Nodes explored: ', 582092)
('Path found, length', 582092)
('Time elapsed: ', 0.9704020023345947, '\n')
Saving Image
python profile.py  76.46s user 1.72s system 100% cpu 1:17.91 total
```