### PR TITLE
"Import queue" Case Sensitivity

### DIFF
--- a/priority_queue.py
+++ b/priority_queue.py
@@ -4,7 +4,7 @@ import itertools
 
 from FibonacciHeap import FibHeap
 import heapq
-import Queue
+import queue
 
 class PriorityQueue():
     __metaclass__ = ABCMeta


### PR DESCRIPTION
As is "import Queue" will throw an error - it needs to be changed to 'import queue' .