### PR TITLE
Suppressing Decompression Bomb warning.

### DIFF
--- a/solve.py
+++ b/solve.py
@@ -2,6 +2,7 @@ from PIL import Image
 import time
 from mazes import Maze
 from factory import SolverFactory
+Image.MAX_IMAGE_PIXELS = None
 
 # Read command line arguments - the python argparse class is convenient here.
 import argparse


### PR DESCRIPTION
Basically the same pull request as the other one, but with minimal changes to the original file. Alternatively, instead of `Image.MAX_IMAGE_PIXELS = None`, we could do `Image.MAX_IMAGE_PIXELS = 225030001`, since that's your biggest included maze, I believe. This would allow for everything provided to work, while also still keeping a hard upper limit.

But it's your call, obviously.

(I made this pull request because I'm a crazy obsessed fan. And because I'm a bit more active than the other person, and have kept it in it's original state.)