### PR TITLE
Fix python related issues

### DIFF
--- a/mazes.py
+++ b/mazes.py
@@ -5,6 +5,9 @@ class Maze:
             self.Neighbours = [None, None, None, None]
             #self.Weights = [0, 0, 0, 0]
 
+        def __lt__(self, other):
+            return True
+
     def __init__(self, im):
 
         width = im.size[0]

--- a/priority_queue.py
+++ b/priority_queue.py
@@ -4,7 +4,7 @@ import itertools
 
 from FibonacciHeap import FibHeap
 import heapq
-import Queue
+import queue
 
 class PriorityQueue():
     __metaclass__ = ABCMeta
@@ -88,7 +88,7 @@ class HeapPQ(PriorityQueue):
 
 class QueuePQ(PriorityQueue):
     def __init__(self):
-        self.pq = Queue.PriorityQueue()
+        self.pq = queue.PriorityQueue()
         self.removed = set()
         self.count = 0
 

--- a/profile_all.py
+++ b/profile_all.py
@@ -32,7 +32,7 @@ def profile():
     for m in methods:
         for i in inputs:
             with tempfile.NamedTemporaryFile(suffix='.png') as tmp:
-                solve(SolverFactory(), m, "examples/%s.png" % i, tmp.name)
+                solve(SolverFactory(), m, "examples/%s.png" % i, tmp)
 
 profiler = BProfile('profiler.png')
 with profiler:


### PR DESCRIPTION
Fixed Queue -> queue (#18)
Fixed the TypeError < operator between Maze.Node objects (https://github.com/mikepound/mazesolving/issues/14) 

Verified by running `python ./solve.py -m dijkstra examples/braid2k.png braid2k_out.png`
Also, now the profiler works again very well.